### PR TITLE
chore(renovate): set automerge strategy to `squash`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,7 @@
     "baseBranches": ["main"],
     "minimumReleaseAge": "3 days",
     "rollbackPrs": true,
+    "automergeStrategy": "squash",
     "reviewers": ["@lapotor", "@whyauthentic"],
     "packageRules": [
         {


### PR DESCRIPTION
This change configures the automerge strategy for Renovatebot to use `squash`. 

Ensures that pull requests from Renovatebot are automatically merged with a squashed commit.