### PR TITLE
test(AuthController): ensure proper cleanup of user in AuthControllerTest

### DIFF
--- a/tests/Feature/AuthControllerTest.php
+++ b/tests/Feature/AuthControllerTest.php
@@ -44,6 +44,8 @@ class AuthControllerTest extends TestCase
             ]);
 
         $this->assertAuthenticatedAs($user);
+
+        $user->delete();
     }
 
     /**


### PR DESCRIPTION
Fixes an issue in AuthControllerTest where the user created for testing purposes is not deleted after test execution. Ensure proper cleanup by deleting the user once AuthControllerTest completes. This improvement enhances the reliability and consistency of the testing environment, preventing any unwanted artifacts from lingering after the test suite runs.