### PR TITLE
fix(ApiResponse): set `Accept` and `Content-Type` headers to `application/json`

### DIFF
--- a/app/Http/Responses/ApiErrorResponse.php
+++ b/app/Http/Responses/ApiErrorResponse.php
@@ -18,7 +18,7 @@ class ApiErrorResponse implements Responsable
         private $message,
         private ?Throwable $exception = null,
         private int $status = Response::HTTP_INTERNAL_SERVER_ERROR,
-        private array $headers = []
+        private array $headers = ["Content-Type" => "application/json", "Accept" => "application/json"]
     ) {}
 
     /**

--- a/app/Http/Responses/ApiSuccessResponse.php
+++ b/app/Http/Responses/ApiSuccessResponse.php
@@ -16,7 +16,7 @@ class ApiSuccessResponse implements Responsable
     public function __construct(
         private $data,
         private int $status = Response::HTTP_OK,
-        private array $headers = []
+        private array $headers = ["Content-Type" => "application/json", "Accept" => "application/json"]
     ) {}
 
     /**


### PR DESCRIPTION
Fixes that the API responses were missing the necessary headers. This ensures that the `Accept` and `Content-Type` headers are correctly set to `application/json` for improved compatibility and adherence to best practices in API development.