### PR TITLE
chore(renovate): restrict major PHP updates, mandate approval for minors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,9 +17,21 @@
     "reviewers": ["@lapotor", "@whyauthentic"],
     "packageRules": [
         {
-            "description": "Disable major and minor updates for PHP",
+            "description": "Allow ranges for PHP",
             "matchPackageNames": "php",
             "rangeStrategy": "auto"
+        },
+        {
+            "description": "Require approval for minor updates on PHP",
+            "matchPackageNames": "php",
+            "matchUpdateTypes": ["minor"],
+            "dependencyDashboardApproval": true
+        },
+        {
+            "description": "Disallow major updates for PHP",
+            "matchPackageNames": "php",
+            "matchUpdateTypes": ["major"],
+            "enabled": false
         }
     ]
 }


### PR DESCRIPTION
This enforces a versioning policy for PHP updates via renovatebot. It disallows major updates and mandates approval for minor updates. This ensures tighter control over PHP version changes, enhancing our maintenance and compatibility standards.