### PR TITLE
ci: add workflow for automated Docker image build and publish

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,9 +6,6 @@ on:
       - main
   release:
     types: [published]
-  pull_request:
-    branches:
-      - "*"
   workflow_dispatch:
 
 env:
@@ -41,10 +38,9 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha
+            type=sha,format=long
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Introduce a new GitHub Actions workflow to automate the process of building and publishing Docker images to the GitHub Container Registry. Configure the workflow to trigger on branch references (`type=ref,event=branch`) and specific semantic versioning patterns (`type=semver,pattern={{version}}`, `type=semver,pattern={{major}}.{{minor}}`). Additionally, include a commit SHA in long format (`type=sha,format=long`) as part of the versioning strategy.