### PR TITLE
docs: update `swagger.yml` for PUT method

### DIFF
--- a/.github/assets/swagger,yml
+++ b/.github/assets/swagger,yml
@@ -100,7 +100,7 @@ paths:
                     $ref: "#/responses/404"
                 "500":
                     $ref: "#/responses/500"
-        patch:
+        put:
             tags:
                 - Shows
             summary: "Updates an existing show by ID."
@@ -181,7 +181,7 @@ paths:
                             $ref: "#/definitions/Request"
                 "500":
                     $ref: "#/responses/500"
-        post:
+        put:
             tags:
                 - Requests
             summary: "Sends a request to the radio station's wishbox."
@@ -319,7 +319,7 @@ paths:
                     $ref: "#/responses/404"
                 "500":
                     $ref: "#/responses/500"
-        patch:
+        put:
             tags:
                 - User
             summary: "Updates a user by ID."
@@ -470,7 +470,7 @@ paths:
                     $ref: "#/responses/404"
                 "500":
                     $ref: "#/responses/500"
-        patch:
+        put:
             tags:
                 - Role
             summary: "Update a role"


### PR DESCRIPTION
Update the Swagger file to reflect the use of the PUT method instead of PATCH. This change ensures that the API documentation accurately represents the current implementation, enhancing clarity and correctness in the documentation.