### PR TITLE
chore: add lockfile maintenance preset for renovatebot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
         ":timezone(Europe/Berlin)",
         ":pinAllExceptPeerDependencies",
         ":rebaseStalePrs",
+        ":maintainLockFilesWeekly",
         ":label(Scope: Deps)"
     ],
     "baseBranches": ["main"],


### PR DESCRIPTION
Introduce lockfile maintenance preset for renovatebot. Streamline dependency management by improving lockfile maintenance. Ensure consistency and reliability.