### PR TITLE
chore: initialize config.platform.php with PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,9 @@
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "php-http/discovery": true
+        },
+        "platform": {
+            "php": "8.1"
         }
     },
     "minimum-stability": "stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "249c361465c7b0808bd8942da35b24d6",
+    "content-hash": "257872fc6f103f98e4519c2c9beafa85",
     "packages": [
         {
             "name": "brick/math",
@@ -8239,5 +8239,8 @@
         "php": "^8.1"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.1"
+    },
     "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Set the `config.platform.php` key in `composer.json` to initialize with PHP version 8.1. This ensures Composer assumes the specified PHP version for the project's platform.