### PR TITLE
feat(api): add Show Model and CRUD Endpoints

### DIFF
--- a/.github/assets/openapi.yml
+++ b/.github/assets/openapi.yml
@@ -18,61 +18,61 @@ paths:
       parameters:
         - name: start_date
           in: query
-          description: Start date of the broadcast schedule.
+          description: >
+            Start of the time range ([ISO 8601](https://wikipedia.org/wiki/ISO_8601), UTC).
+            If omitted, defaults to the current time.
           schema:
             type: string
             format: date-time
         - name: end_date
           in: query
-          description: End date of the broadcast schedule. End date must be less than 30 days from today if not logged in
+          description: >
+            End of the time range ([ISO 8601](https://wikipedia.org/wiki/ISO_8601), UTC).
+            Must not be used together with `days`.
           schema:
             type: string
             format: date-time
+        - name: days
+          in: query
+          description: >
+            Number of days to return starting from `start_date`
+            (or from now if `start_date` is omitted).
+            Must not be used together with `end_date`.
+          schema:
+            minimum: 1
+            maximum: 30
+            type: integer
         - name: live
           in: query
-          description: If only live shows or not live shows should be returned.
+          description: Whether live or non-live shows should be shown. If not set both will be shown.
           schema:
             type: boolean
-        - name: moderator[]
+        - name: moderator_ids
           in: query
-          description: Array of user ids which shows should be returned.
+          description: Filter for moderators on the shows by Ids
+          style: form
+          explode: true
           schema:
             type: array
             items:
               type: integer
-        - name: primary
-          in: query
-          description: If only show should returned where `moderator[]` is primary.
-          schema:
-            type: boolean
+            uniqueItems: true
         - name: sort
           in: query
           schema:
             type: string
             enum:
-              - id
-              - id:asc
-              - id:desc
-              - start_date
-              - start_date:asc
-              - start_date:desc
-              - end_date
-              - end_date:asc
-              - end_date:desc
+            - id
+            - start_date
+            - end_date
             default: start_date
-        - name: per_page
+        - name: order
           in: query
-          description: Items to load per page.
           schema:
-            type: integer
-            maximum: 50
-            default: 25
-        - name: page
-          in: query
-          description: Page to load.
-          schema:
-            type: integer
-            default: 1
+            type: string
+            enum: [asc, desc]
+            default: asc
+            
       responses:
         "200":
           description: OK
@@ -83,10 +83,10 @@ paths:
                 items:
                   $ref: "#/components/schemas/Show"
         "500":
-          description:
-            "Internal Server Error - A generic error message, given when\
-            \ an unexpected condition was encountered and no more specific message\
-            \ is suitable."
+          description: >
+            Internal Server Error - A generic error message, given when
+            an unexpected condition was encountered and no more specific message
+            is suitable.
           content:
             application/json:
               schema:
@@ -1228,7 +1228,8 @@ components:
         - body
         - start_date
         - end_date
-        - moderators
+        - moderator
+        - co_moderators
         - is_live
         - enabled
         - locked_by
@@ -1250,23 +1251,14 @@ components:
         end_date:
           type: string
           format: date-time
-        moderators:
-          minItems: 1
+        moderator:
+          description: 'The primary moderator'
+          type: integer
+        co_moderators:
           type: array
+          uniqueItems: true
           items:
-            type: object
-            required:
-              - id
-              - name
-              - primary
-            properties:
-              id:
-                type: integer
-              name:
-                type: string
-                readOnly: true
-              primary:
-                type: boolean
+            type: integer
         is_live:
           type: boolean
         enabled:

--- a/.github/assets/swagger.yml
+++ b/.github/assets/swagger.yml
@@ -24,16 +24,55 @@ paths:
             format: date-time
         - name: end_date
           in: query
-          description: End date of the broadcast schedule.
+          description: End date of the broadcast schedule. End date must be less than 30 days from today if not logged in
           schema:
             type: string
             format: date-time
-        - name: days
+        - name: live
           in: query
-          description: Number of days for which to return the broadcast schedule.
+          description: If only live shows or not live shows should be returned.
           schema:
-            maximum: 30
+            type: boolean
+        - name: moderator[]
+          in: query
+          description: Array of user ids which shows should be returned.
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: primary
+          in: query
+          description: If only show should returned where `moderator[]` is primary.
+          schema:
+            type: boolean
+        - name: sort
+          in: query
+          schema:
+            type: string
+            enum:
+              - id
+              - id:asc
+              - id:desc
+              - start_date
+              - start_date:asc
+              - start_date:desc
+              - end_date
+              - end_date:asc
+              - end_date:desc
+            default: start_date
+        - name: per_page
+          in: query
+          description: Items to load per page.
+          schema:
             type: integer
+            maximum: 50
+            default: 25
+        - name: page
+          in: query
+          description: Page to load.
+          schema:
+            type: integer
+            default: 1
       responses:
         "200":
           description: OK

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,34 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Support\Facades\Validator;
+
 abstract class Controller
 {
-    //
+    use AuthorizesRequests, ValidatesRequests;
+
+    /**
+     * Validates the given parameters based on the provided casts and rules.
+     *
+     * @param array $params The parameters to be validated.
+     * @param array $casts The casting rules for the parameters.
+     * @param array $rules The validation rules for the parameters.
+     * @return array The validated parameters.
+     */
+    protected function validateParams($params, $casts, $rules): array
+    {
+        foreach ($casts as $key => $cast) {
+            if (isset($params[$key])) {
+                if ($cast === 'boolean') {
+                    $params[$key] = filter_var($params[$key], FILTER_VALIDATE_BOOLEAN);
+                } else {
+                    settype($params[$key], $cast);
+                }
+            }
+        }
+
+        return Validator::make($params, $rules)->validate();
+    }
 }

--- a/app/Http/Controllers/ShowController.php
+++ b/app/Http/Controllers/ShowController.php
@@ -213,7 +213,7 @@ class ShowController extends Controller
          * it should return the given amount of shows per page.
          * If "per_page" isn't set, it should return 25 shows per page, maximum 50.
          */
-        if ($request->sort !== null && $request->per_page <= 50) {
+        if ($request->per_page <= 50) {
             $res = $shows->paginate($request->per_page);
         } else {
             $res = $shows->paginate(25);

--- a/app/Http/Controllers/ShowController.php
+++ b/app/Http/Controllers/ShowController.php
@@ -4,20 +4,87 @@ namespace App\Http\Controllers;
 
 use App\Http\Resources\ShowResource;
 use App\Http\Responses\ApiErrorResponse;
+use App\Http\Responses\ApiSuccessResponse;
 use App\Models\Show;
+use App\Models\User;
 use App\Permissions\ShowsPermissions;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ShowController extends Controller
 {
+
+    /**
+     * Check if there are any other shows that overlap with the given start and end dates.
+     * If the start date is the same as the end date of another show, it should return false and vice versa.
+     *
+     * @param string $start_date The start date of the show.
+     * @param string $end_date The end date of the show.
+     * @param int|null $show_id The id of the show to exclude from the check.
+     * @return bool Returns true if there are no overlapping shows, false otherwise.
+     */
+    private function _checkForOtherShow(string $start_date, string $end_date, int|null $show_id = null, bool|null $enabled = true): bool
+    {
+        $overlapCount = Show::query();
+
+        if ($enabled !== null) {
+            $overlapCount->where('enabled', '=', $enabled);
+        }
+
+        $overlapCount->where(function ($query) use ($start_date, $end_date) {
+            $query->where(function ($query) use ($start_date) {
+                $query->where(function ($query) use ($start_date) {
+                    $query->whereRaw('? BETWEEN `start_date` AND `end_date`', [$start_date]);
+                });
+                $query->where(function ($query) use ($start_date) {
+                    $query->where('end_date', '!=', [$start_date]);
+                });
+            });
+
+            $query->orWhere(function ($query) use ($end_date) {
+                $query->where(function ($query) use ($end_date) {
+                    $query->whereRaw('? BETWEEN `start_date` AND `end_date`', [$end_date]);
+                });
+                $query->where(function ($query) use ($end_date) {
+                    $query->where('start_date', '!=', [$end_date]);
+                });
+            });
+            $query->orWhere(function ($query) use ($start_date, $end_date) {
+                $query->where('start_date', '<=', $start_date);
+                $query->where('end_date', '>=', $end_date);
+            });
+        });
+
+        if ($show_id !== null) {
+            $overlapCount->where('id', '!=', $show_id);
+        }
+
+        return $overlapCount->count() === 0;
+    }
+
+    /**
+     * ShowController constructor.
+     *
+     * This method initializes the ShowController class.
+     * It sets up the necessary middleware for specific actions.
+     */
+    public function __construct()
+    {
+        $this->middleware('permission:' . ShowsPermissions::CAN_CREATE_SHOWS . '|' . ShowsPermissions::CAN_CREATE_SHOWS_OTHERS)
+            ->only(['store']);
+        $this->middleware('permission:' . ShowsPermissions::CAN_UPDATE_SHOWS . '|' . ShowsPermissions::CAN_UPDATE_SHOWS_OTHERS)
+            ->only(['update']);
+        $this->middleware('permission:' . ShowsPermissions::CAN_DELETE_SHOWS . '|' . ShowsPermissions::CAN_DELETE_SHOWS_OTHERS)
+            ->only(['delete']);
+    }
 
     /**
      * Retrieve a paginated list of shows based on the provided query parameters.
      *
      * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection | \App\Http\Responses\ApiErrorResponse
      */
-    public function index()
+    public function index(Request $request)
     {
         static $SORT_OPTIONS = [
             'id',
@@ -31,19 +98,7 @@ class ShowController extends Controller
             'end_date:desc',
         ];
 
-        $casts = [
-            'start_date' => 'date',
-            'end_date' => 'date',
-            'days' => 'integer',
-            'live' => 'boolean',
-            'moderator' => 'array',
-            'moderator.*' => 'integer',
-            'primary' => 'boolean',
-            'sort' => 'string',
-            'per_page' => 'integer',
-        ];
-
-        $rules = [
+        $request->validate([
             'start_date' => ['required', 'date', 'before:end_date'],
             'end_date' => ['required', 'date', 'after:start_date'],
             'live' => 'boolean',
@@ -53,9 +108,13 @@ class ShowController extends Controller
             'sort' => ['string', 'in:' . implode(',', $SORT_OPTIONS)],
             'per_page' => 'integer',
 
-        ];
+        ]);
 
-        $validated = $this->validateParams(request()->all(), $casts, $rules);
+        $request['start_date'] = $request->date('start_date')->toDateTimeString();
+        $request['end_date'] = $request->date('end_date')->toDateTimeString();
+
+        /** @var \App\Models\User $user */
+        $user = $request->user('sanctum');
 
         $shows = Show::query()->with([
             "moderators" => function ($query) {
@@ -63,11 +122,11 @@ class ShowController extends Controller
             }
         ]);
 
-        if (!auth()->check()) {
-            if ($validated['start_date'] < today() ) {
+        if ($user === null) {
+            if ($request->start_date < today() ) {
                 return new ApiErrorResponse('Start date must be greater than today.', status: Response::HTTP_BAD_REQUEST);
             }
-            if ($validated['end_date'] > today()->addMonth() ) {
+            if ($request->end_date > today()->addMonth() ) {
                 return new ApiErrorResponse('End date must be less than 30 days from today.', status: Response::HTTP_BAD_REQUEST);
             }
 
@@ -75,37 +134,33 @@ class ShowController extends Controller
         }
 
 
-        $shows->where(function ($query) use ($validated) {
+        $shows->where(function ($query) use ($request) {
             $query->whereBetween('start_date',
                 [
-                    $validated['start_date'],
-                    $validated['end_date'],
+                    $request->start_date,
+                    $request->end_date,
                 ]);
             $query->orWhereBetween('end_date',
                 [
-                    $validated['start_date'],
-                    $validated['end_date'],
+                    $request->start_date,
+                    $request->end_date,
                 ]);
         });
 
         /**
          * Hide shows that are not enabled and the primary moderator is not the current user.
          */
-        if (auth()->check()) {
-            /** @var \App\Models\User $user */
-            $user = auth()->user();
-            if (!$user->hasPermissionTo(ShowsPermissions::CAN_VIEW_DISABLED_SHOWS_OTHERS)) {
-                $shows->where(function ($query) use ($user) {
-                    $query->where('enabled', '=', true)
-                        ->orWhere(function ($query) use ($user) {
-                            $query->where('enabled', '=', false)
-                                ->whereHas('moderators', function ($query) use ($user) {
-                                    $query->where('moderator_id', '=', $user->id)
-                                        ->where('primary', '=', true);
-                            });
-                    });
+        if ($user !== null && !$user->hasPermissionTo(ShowsPermissions::CAN_VIEW_DISABLED_SHOWS_OTHERS)) {
+            $shows->where(function ($query) use ($user) {
+                $query->where('enabled', '=', true)
+                    ->orWhere(function ($query) use ($user) {
+                        $query->where('enabled', '=', false)
+                            ->whereHas('moderators', function ($query) use ($user) {
+                                $query->where('moderator_id', '=', $user->id)
+                                    ->where('primary', '=', true);
+                        });
                 });
-            }
+            });
         }
 
         /**
@@ -113,22 +168,22 @@ class ShowController extends Controller
          * If it is, it should return only shows that are live or not live,
          * depending on the value of the query parameter "live".
          */
-        if (isset($validated['live'])) {
-            $shows->where('is_live', '=', $validated['live']);
+        if ($request->live !== null) {
+            $shows->where('is_live', '=', $request->live);
         }
 
         /**
          * If the query parameter "moderator" is set,
          * it should return only shows that have the given user as a moderator.
          */
-        if (isset($validated['moderator'])) {
-            $shows->whereHas('moderators', function ($query) use ($validated) {
-                $query->whereIn('moderator_id', $validated['moderator']);
+        if ($request->moderator !== null && count($request->moderator) > 0) {
+            $shows->whereHas('moderators', function ($query) use ($request) {
+                $query->whereIn('moderator_id', $request->moderator);
                 // If the query parameter "primary" is set,
                 // it should return only shows that have the given user as a primary moderator or not,
                 // depending on the value of the query parameter "primary".
                 if (isset($validated['primary'])) {
-                    $query->where('primary', '=', $validated['primary']);
+                    $query->where('primary', '=', $request->primary);
                 }
             });
         }
@@ -138,9 +193,9 @@ class ShowController extends Controller
          * it should return the shows sorted by the given field.
          * If the query parameter "sort" isn't set, it should return the shows sorted by start date.
          */
-        if (isset($validated['sort'])) {
-            $sort = explode(':', $validated['sort']);
-            if (in_array($validated['sort'], $SORT_OPTIONS)) {
+        if ($request->sort !== null) {
+            $sort = explode(':', $request->sort);
+            if (in_array($request->sort, $SORT_OPTIONS)) {
                 if (count($sort) === 1) {
                     $shows->orderBy($sort[0]);
                 } else {
@@ -151,15 +206,23 @@ class ShowController extends Controller
             $shows->orderBy('start_date');
         }
 
+
+
         /**
          * If the query parameter "per_page" is set,
          * it should return the given amount of shows per page.
          * If "per_page" isn't set, it should return 25 shows per page, maximum 50.
          */
-        if (isset($validated['per_page']) && $validated['per_page'] <= 50) {
-            $res = $shows->paginate($validated['per_page']);
+        if ($request->sort !== null && $request->per_page <= 50) {
+            $res = $shows->paginate($request->per_page);
         } else {
             $res = $shows->paginate(25);
+        }
+
+        if ($user === null) {
+            $res = collect($res->items())->map(function ($show) {
+                return $show->makeHidden('locked_by');
+            });
         }
 
         return ShowResource::collection($res);
@@ -167,52 +230,403 @@ class ShowController extends Controller
 
     /**
      * Store a newly created resource in storage.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \App\Http\Resources\ShowResource | \App\Http\Responses\ApiErrorResponse
      */
     public function store(Request $request)
     {
-
         $request->validate([
+            'title' => 'required|string',
+            'body' => 'presemt|string|nullable',
             'start_date' => 'required|date|before:end_date',
             'end_date' => 'required|date|after:start_date',
+            'live' => 'required|boolean',
+            'enabled' => 'required|boolean',
+            'moderators' => 'required|array',
+            'moderators.*' => 'required|array',
+            'moderators.*.id' => 'required|integer|distinct|exists:users,id',
+            'moderators.*.primary' => 'required|boolean',
         ]);
-        // Check if there is a show which overlaps with the given start and end date.
-        $overlapCount = Show::query();
 
-        $overlapCount->where(function ($query) use ($request) {
-            $query->whereRaw('? BETWEEN start_date AND end_date', [$request->start_date]);
-        });
-        $overlapCount->orWhere(function ($query) use ($request) {
-            $query->whereRaw('? BETWEEN start_date AND end_date', [$request->end_date]);
-        });
-        $overlapCount->orWhere(function ($query) use ($request) {
-            $query->where('start_date', '<=', $request->start_date);
-            $query->where('end_date', '>=', $request->end_date);
+        // Get the primary moderator.
+        $primaryModerator = collect($request->moderators)->filter(function ($moderator) {
+            return $moderator['primary'] === true;
         });
 
-        echo $overlapCount->count();
+        /**
+         * A show must have exactly one primary moderator.
+         */
+        if ($primaryModerator->count() !== 1) {
+            return new ApiErrorResponse('There must be exactly one primary moderator.', status: Response::HTTP_BAD_REQUEST);
+        }
+
+        /** @var \App\Models\User $user */
+        $user = auth()->user();
+
+        /**
+         * Check if the user is the primary moderator of the show.
+         */
+        if ($primaryModerator->first()['id'] !== $user->id) {
+            if (!$user->checkPermissionTo(ShowsPermissions::CAN_CREATE_SHOWS_OTHERS, 'web')) {
+                return new ApiErrorResponse('You are not allowed to create shows for others.', status: Response::HTTP_FORBIDDEN);
+            }
+        }
+
+        /**
+         * Convert the start and end date to datetime strings.
+         */
+        $request['start_date'] = $request->date('start_date')->toDateTimeString();
+        $request['end_date'] = $request->date('end_date')->toDateTimeString();
+
+        /**
+         * Check if the show collides with another show.
+         */
+        if (!$this->_checkForOtherShow($request->start_date, $request->end_date)) {
+            return new ApiErrorResponse('There is already a show scheduled for this time.', status: Response::HTTP_BAD_REQUEST);
+        }
+
+        // Get the primary moderator.
+        $primaryModerator = User::find($primaryModerator->first()['id']);
+
+        /**
+         * Check if the primary moderator has the permission to be a primary moderator.
+         */
+        if (!$primaryModerator->checkPermissionTo(ShowsPermissions::CAN_BE_PRIMARY_MODERATOR)) {
+            return new ApiErrorResponse('The primary moderator, "'. $primaryModerator->name .'" does not have the permission to be a primary moderator.', status: Response::HTTP_BAD_REQUEST);
+        }
+
+        // Get the non-primary moderators.
+        $nonPrimaryModerators = collect($request->moderators)->filter(function ($moderator) {
+            return $moderator['primary'] === false;
+        });
+
+        /**
+         * If there are non-primary moderators, check if the user has the permission to add non-primary moderators.
+         */
+        if ($nonPrimaryModerators->count() > 0) {
+            if (!$user->checkPermissionTo(ShowsPermissions::CAN_ADD_MODERATORS, 'web')) {
+                return new ApiErrorResponse('You are not allowed to add non-primary moderators.', status: Response::HTTP_FORBIDDEN);
+            }
+            /**
+             * Check if the non-primary moderators have the permission to be a moderator.
+             */
+            foreach ($nonPrimaryModerators as $nonPrimaryModerator) {
+                $nonPrimaryModerator = User::find($nonPrimaryModerator['id']);
+                if (!$nonPrimaryModerator->checkPermissionTo(ShowsPermissions::CAN_BE_MODERATOR)) {
+                    return new ApiErrorResponse('"'  . $nonPrimaryModerator->name. '" does not have the permission to be a non-primary moderator.', status: Response::HTTP_BAD_REQUEST);
+                }
+            }
+        }
+
+        /**
+         * If the show is live, check if the user has the permission to set live shows.
+         */
+        if ($request->live && !$user->checkPermissionTo(ShowsPermissions::CAN_SET_LIVE_SHOWS, 'web')) {
+            return new ApiErrorResponse('You are not allowed to set shows live.', status: Response::HTTP_FORBIDDEN);
+        }
+
+        /**
+         * If the show is enabled, check if the user has the permission to enable shows.
+         */
+        if ($request->enabled && !$user->checkPermissionTo(ShowsPermissions::CAN_ENABLE_SHOWS, 'web')) {
+            return new ApiErrorResponse('You are not allowed to enable shows.', status: Response::HTTP_FORBIDDEN);
+        }
+
+        $show = new Show();
+        $show->title = $request->title;
+        $show->body = $request->body;
+        $show->start_date = $request->start_date;
+        $show->end_date = $request->end_date;
+        $show->is_live = $request->live;
+        $show->enabled = $request->enabled;
+
+        if (!$show->save()) {
+            return new ApiErrorResponse('Something went wrong.');
+        }
+
+        try {
+            $show->moderators()->sync(
+                collect($request->moderators)->mapWithKeys(function ($moderator) {
+                    return [$moderator['id'] => ['primary' => $moderator['primary']]];
+                })
+            );
+        } catch (\Exception $e) {
+            $show->delete();
+            return new ApiErrorResponse('Something went wrong.', $e);
+        }
+
+        $show->load([
+            "moderators" => function ($query) {
+                $query->withPivot('primary');
+            }
+        ]);
+
+        return new ShowResource($show->makeHidden('primary_moderator'));
     }
 
     /**
      * Display the specified resource.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \App\Models\Show $show
+     * @return \App\Http\Resources\ShowResource | \App\Http\Responses\ApiErrorResponse
      */
-    public function show(Show $show)
+    public function show(Request $request, Show $show)
     {
-        //
+        $IS_USER_LOGGED_IN = $request->user('sanctum') !== null;
+        /**
+         * If the show is disabled and the user is not logged in,
+         * it should return a 404 error.
+         */
+        if (!$IS_USER_LOGGED_IN) {
+            if ($show->enabled == false) {
+                throw new NotFoundHttpException('No query results for model [App\\Models\\Show] ' . $show->id, code: Response::HTTP_NOT_FOUND, headers: ['Accept' => 'application/json', 'Content-Type' => 'application/json']);
+            }
+        }
+
+        /**
+         * If the show is disabled and the user is logged in,
+         * it should return a 404 error if the user is not a moderator of the show
+         * and doesn't have the permission to view disabled shows of others.
+         */
+        if ($IS_USER_LOGGED_IN) {
+            /** @var \App\Models\User $user */
+            $user = $request->user('sanctum');
+            $isPrimaryModerator = $show->moderators()->where('moderator_id', '=', $user->id)->where('primary', '=', true)->exists();
+            if (!$isPrimaryModerator) {
+                if ($show->enabled == false && !$user->checkPermissionTo(ShowsPermissions::CAN_VIEW_DISABLED_SHOWS_OTHERS, 'web')) {
+                    throw new NotFoundHttpException('No query results for model [App\\Models\\Show] ' . $show->id, code: Response::HTTP_NOT_FOUND, headers: ['Accept' => 'application/json', 'Content-Type' => 'application/json']);
+                }
+            }
+        }
+
+        if (!$IS_USER_LOGGED_IN) {
+            $show->makeHidden('locked_by');
+        }
+
+        $show->load([
+            "moderators" => function ($query) {
+                $query->withPivot('primary');
+            }
+        ]);
+
+        return new ShowResource($show);
     }
 
     /**
      * Update the specified resource in storage.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \App\Models\Show $show
+     * @return \App\Http\Resources\ShowResource | \App\Http\Responses\ApiErrorResponse
      */
     public function update(Request $request, Show $show)
     {
-        //
+        $request->validate([
+            'title' => 'required|string',
+            'body' => 'sometimes|string',
+            'start_date' => 'required|date|before:end_date',
+            'end_date' => 'required|date|after:start_date',
+            'live' => 'required|boolean',
+            'enabled' => 'required|boolean',
+            'moderators' => 'required|array',
+            'moderators.*' => 'required|array',
+            'moderators.*.id' => 'required|integer|distinct|exists:users,id',
+            'moderators.*.primary' => 'required|boolean',
+        ]);
+
+        /** @var \App\Models\User $user */
+        $user = auth()->user();
+
+        // Check if the user is the primary moderator of the show.
+        $isPrimaryModerator = $show->moderators()->where('moderator_id', '=', $user->id)->where('primary', '=', true)->exists();
+
+        /**
+         * If the show is disabled and the user is logged in,
+         * it should return a 404 error if the user is not a moderator of the show
+         * and doesn't have the permission to view disabled shows of others.
+         */
+        if (!$isPrimaryModerator && $show->enabled === false && !$user->checkPermissionTo(ShowsPermissions::CAN_VIEW_DISABLED_SHOWS_OTHERS)) {
+            throw new NotFoundHttpException(
+                'No query results for model [App\\Models\\Show] ' . $show->id,
+                code: Response::HTTP_NOT_FOUND,
+                headers: ['Accept' => 'application/json', 'Content-Type' => 'application/json']
+            );
+        }
+
+        /**
+         * Check if the show is currently locked by another user.
+         */
+        if ($show->locked_by !== null && $show->locked_by !== $user->id) {
+            return new ApiErrorResponse('The show is currently locked by another user.', status: Response::HTTP_LOCKED);
+        }
+
+        /**
+         * If the user is not the primary moderator of the show, and doesn't have the permission to update shows of others,
+         * it should return a 403 error.
+         */
+        if (!$isPrimaryModerator && !$user->checkPermissionTo(ShowsPermissions::CAN_UPDATE_SHOWS_OTHERS, 'web')) {
+            return new ApiErrorResponse('You are not allowed to update shows of others.', status: Response::HTTP_FORBIDDEN);
+        }
+
+        /**
+         * Check if the show collides with another show.
+         */
+        if (!$this->_checkForOtherShow($request->start_date, $request->end_date, $show->id)) {
+            return new ApiErrorResponse('There is already a show scheduled for this time.', status: Response::HTTP_BAD_REQUEST);
+        }
+
+        /**
+         * Get primary moderators.
+         */
+        $primaryModerator = collect($request->moderators)->filter(function ($moderator) {
+            return $moderator['primary'] === true;
+        });
+
+        /**
+         * A show must have exactly one primary moderator.
+         */
+        if ($primaryModerator->count() !== 1) {
+            return new ApiErrorResponse('There must be exactly one primary moderator.', status: Response::HTTP_BAD_REQUEST);
+        }
+
+        // Get the new primary moderator.
+        $newPrimaryModerator = User::find($primaryModerator->first()['id']);
+
+        /**
+         * Check if the primary moderator is the same as the old primary moderator,
+         * and if not, check if the user has the permission to update shows of others.
+         */
+        if ($newPrimaryModerator->id !== $show->primary_moderator->first()->id) {
+            if (!$user->checkPermissionTo(ShowsPermissions::CAN_UPDATE_SHOWS_OTHERS, 'web')) {
+                return new ApiErrorResponse('You are not allowed to update shows of others.', status: Response::HTTP_FORBIDDEN);
+            }
+        }
+
+        /**
+         * Check if the new primary moderator has the permission to be a primary moderator.
+         */
+        if (!$newPrimaryModerator->checkPermissionTo(ShowsPermissions::CAN_BE_PRIMARY_MODERATOR)) {
+            return new ApiErrorResponse('The new primary moderator, "'. $newPrimaryModerator->name .'" does not have the permission to be a primary moderator.', status: Response::HTTP_BAD_REQUEST);
+        }
+
+        // Get the non-primary moderators.
+        $nonPrimaryModerators = collect($request->moderators)->filter(function ($moderator) {
+            return $moderator['primary'] === false;
+        });
+
+        /**
+         * Check if there are any moderators that are not primary moderators.
+         * If there are, check if the user has changed the moderators.
+         * If the user has changed the moderators, check if the user has the permission to add non-primary moderators.
+         */
+        if ($nonPrimaryModerators->count() > 0) {
+            // Check if the user has changed the moderators itself.
+            $oldNonPrimaryModerators = $show->moderators()->where('primary', '=', false)->get();
+            $oldNonPrimaryModeratorsIds = $oldNonPrimaryModerators->pluck('id')->toArray();
+            $newNonPrimaryModeratorsIds = collect($nonPrimaryModerators)->pluck('id')->toArray();
+            if ($oldNonPrimaryModeratorsIds !== $newNonPrimaryModeratorsIds) {
+                if (!$user->checkPermissionTo(ShowsPermissions::CAN_ADD_MODERATORS, 'web')) {
+                    return new ApiErrorResponse('You are not allowed to add non-primary moderators.', status: Response::HTTP_FORBIDDEN);
+                }
+                /**
+                 * Check if the non-primary moderators have the permission to be a moderator.
+                 */
+                foreach ($nonPrimaryModerators as $nonPrimaryModerator) {
+                    $nonPrimaryModerator = User::find($nonPrimaryModerator['id']);
+                    if (!$nonPrimaryModerator->checkPermissionTo(ShowsPermissions::CAN_BE_MODERATOR)) {
+                        return new ApiErrorResponse('"'  . $nonPrimaryModerator->name. '" does not have the permission to be a non-primary moderator.', status: Response::HTTP_BAD_REQUEST);
+                    }
+                }
+            }
+        }
+
+        /**
+         * Check if the is_live field was changed, and if so, check if the user has the permission to change the live status.
+         */
+        if ($show->is_live !== $request->is_live) {
+            if (!$user->checkPermissionTo(ShowsPermissions::CAN_SET_LIVE_SHOWS, 'web')) {
+                return new ApiErrorResponse('You are not allowed to change the live status of shows.', status: Response::HTTP_FORBIDDEN);
+            }
+        }
+
+        /**
+         * Check if the enabled field was changed, and if so, check if the user has the permission to enable or disable shows.
+         */
+        if ($show->enabled !== $request->enabled) {
+            if (!$user->checkPermissionTo(ShowsPermissions::CAN_ENABLE_SHOWS, 'web')) {
+                return new ApiErrorResponse('You are not allowed to enable or disable shows.', status: Response::HTTP_FORBIDDEN);
+            }
+        }
+
+        $show->title = $request->title;
+        $show->body = $request->body;
+        $show->start_date = $request->start_date;
+        $show->end_date = $request->end_date;
+        $show->is_live = $request->is_live;
+        $show->enabled = $request->enabled;
+
+        $show->moderators()->sync(
+            collect($request->moderators)->mapWithKeys(function ($moderator) {
+                return [$moderator['id'] => ['primary' => $moderator['primary']]];
+            })
+        );
+
+        if ($show->save()) {
+            return new ShowResource($show->makeHidden('primary_moderator'));
+        } else {
+            return new ApiErrorResponse('Something went wrong.');
+        }
     }
 
     /**
      * Remove the specified resource from storage.
+     *
+     * @param \App\Models\Show $show
+     * @return \App\Http\Responses\ApiErrorResponse | \App\Http\Responses\ApiSuccessResponse
      */
     public function destroy(Show $show)
     {
-        //
+        /** @var \App\Models\User $user */
+        $user = auth()->user();
+
+        /**
+         * If the show is disabled and the user is not the primary moderator of the show,
+         * it should return a 404 error.
+         */
+        $isPrimaryModerator = $show->moderators()->where('moderator_id', '=', $user->id)->where('primary', '=', true)->exists();
+        if (!$isPrimaryModerator && $show->enabled === false && !$user->checkPermissionTo(ShowsPermissions::CAN_VIEW_DISABLED_SHOWS_OTHERS)) {
+            throw new NotFoundHttpException(
+                'No query results for model [App\\Models\\Show] ' . $show->id,
+                code: Response::HTTP_NOT_FOUND,
+                headers: ['Accept' => 'application/json', 'Content-Type' => 'application/json']
+            );
+        }
+
+        /**
+         * Check if the show is currently locked by another user.
+         */
+        if ($show->locked_by !== null && $show->locked_by !== $user->id) {
+            return new ApiErrorResponse('The show is currently locked by another user.', status: Response::HTTP_LOCKED);
+        }
+
+        /**
+         * If the user is not the primary moderator of the show, and doesn't have the permission to delete shows of others,
+         * it should return a 403 error.
+         */
+        if (!$isPrimaryModerator && !$user->checkPermissionTo(ShowsPermissions::CAN_DELETE_SHOWS_OTHERS, 'web')) {
+            return new ApiErrorResponse('You are not allowed to delete shows of others.', status: Response::HTTP_FORBIDDEN);
+        }
+
+        /**
+         * If the user is the primary moderator of the show, or has the permission to delete shows of others,
+         * it should delete the show.
+         */
+        if ($show->delete()) {
+            return new ApiSuccessResponse('', Response::HTTP_NO_CONTENT);
+        } else {
+            return new ApiErrorResponse('Something went wrong.');
+        }
     }
 }

--- a/app/Http/Controllers/ShowController.php
+++ b/app/Http/Controllers/ShowController.php
@@ -170,7 +170,26 @@ class ShowController extends Controller
      */
     public function store(Request $request)
     {
-        //
+
+        $request->validate([
+            'start_date' => 'required|date|before:end_date',
+            'end_date' => 'required|date|after:start_date',
+        ]);
+        // Check if there is a show which overlaps with the given start and end date.
+        $overlapCount = Show::query();
+
+        $overlapCount->where(function ($query) use ($request) {
+            $query->whereRaw('? BETWEEN start_date AND end_date', [$request->start_date]);
+        });
+        $overlapCount->orWhere(function ($query) use ($request) {
+            $query->whereRaw('? BETWEEN start_date AND end_date', [$request->end_date]);
+        });
+        $overlapCount->orWhere(function ($query) use ($request) {
+            $query->where('start_date', '<=', $request->start_date);
+            $query->where('end_date', '>=', $request->end_date);
+        });
+
+        echo $overlapCount->count();
     }
 
     /**

--- a/app/Http/Controllers/ShowController.php
+++ b/app/Http/Controllers/ShowController.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\ShowResource;
+use App\Models\Show;
+use App\Permissions\ShowsPermissions;
+use Illuminate\Http\Request;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Validator;
+
+class ShowController extends Controller
+{
+
+    /**
+     * Retrieve a paginated list of shows based on the provided query parameters.
+     *
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
+    public function index()
+    {
+
+        static $SORT_OPTIONS = [
+            'id',
+            'id:asc',
+            'id:desc',
+            'start',
+            'start:asc',
+            'start:desc',
+            'end',
+            'end:asc',
+            'end:desc',
+        ];
+
+        $casts = [
+            'start_date' => 'date',
+            'end_date' => 'date',
+            'days' => 'integer',
+            'live' => 'boolean',
+            'moderator' => 'array',
+            'moderator.*' => 'integer',
+            'primary' => 'boolean',
+            'sort' => 'string',
+            'per_page' => 'integer',
+        ];
+
+        $rules = [
+            'start_date' => ['date'],
+            'end_date' => ['exclude_without:start_date', 'date', 'after:start_date'],
+            'days' => ['integer', 'min:1'],
+            'live' => 'boolean',
+            'moderator' => ['array'],
+            'moderator.*' => ['integer', 'distinct', 'exists:users,id'],
+            'primary' => ['boolean', 'exclude_without:moderator'],
+            'sort' => ['string', 'in:' . implode(',', $SORT_OPTIONS)],
+            'per_page' => 'integer',
+
+        ];
+
+        $validated = $this->validateParams(request()->all(), $casts, $rules);
+
+        $shows = Show::query()->with([
+            "moderators" => function ($query) {
+                $query->withPivot('primary');
+            }
+        ]);
+
+        if (!auth()->check()) {
+            $shows->where('enabled', '=', true);
+        }
+
+        $shows->where(function ($query) use ($validated) {
+            $NOW = now();
+            if (isset($validated['start_date'])) {
+                $query->whereBetween('start_date',
+                [
+                    $validated['start_date'],
+                    $validated['end_date'] ?? $validated['days'] ?? $validated['start_date']->addDays(7)
+                ]);
+            } elseif (isset($validated['days']) && !isset($validated['start_date'])) {
+                $inXDays = (clone $NOW)->addDays($validated['days']);
+                $query->whereBetween('start_date',
+                [
+                    $NOW,
+                    $inXDays
+                ])
+                ->orWhereBetween('end_date',
+                [
+                    $NOW,
+                    $inXDays
+                ]);
+            } else {
+                $in7Days = (clone $NOW)->addDays(7);
+                $query->whereBetween('start_date',
+                [
+                    $NOW,
+                    $in7Days
+                ])
+                ->orWhereBetween('end_date',
+                [
+                    $NOW,
+                    $in7Days
+                ]);
+            }
+        });
+
+        /**
+         * Hide shows that are not enabled and the primary moderator is not the current user.
+         */
+        if (auth()->check()) {
+            $user = auth()->user();
+            $shows->where(function ($query) use ($user) {
+                $query->where('enabled', '=', true)
+                    ->orWhere(function ($query) use ($user) {
+                        $query->where('enabled', '=', false)
+                            ->whereHas('moderators', function ($query) use ($user) {
+                                $query->where('moderator_id', '=', $user->id)
+                                    ->where('primary', '=', true);
+                            });
+                    });
+            });
+        }
+
+        /**
+         * Check if the query parameter "live" is set.
+         * If it is, it should return only shows that are live or not live,
+         * depending on the value of the query parameter "live".
+         */
+        if (isset($validated['live'])) {
+            $shows->where('is_live', '=', $validated['live']);
+        }
+
+        /**
+         * If the query parameter "moderator" is set,
+         * it should return only shows that have the given user as a moderator.
+         */
+        if (isset($validated['moderator'])) {
+            $shows->whereHas('moderators', function ($query) use ($validated) {
+                $query->whereIn('moderator_id', $validated['moderator']);
+                // If the query parameter "primary" is set,
+                // it should return only shows that have the given user as a primary moderator or not,
+                // depending on the value of the query parameter "primary".
+                if (isset($validated['primary'])) {
+                    $query->where('primary', '=', $validated['primary']);
+                }
+            });
+        }
+
+        /**
+         * If the query parameter "sort" is set,
+         * it should return the shows sorted by the given field.
+         * If the query parameter "sort" isn't set, it should return the shows sorted by start date.
+         */
+        if (isset($validated['sort'])) {
+            $sort = explode(':', $validated['sort']);
+            if (in_array($validated['sort'], $SORT_OPTIONS)) {
+                if (count($sort) === 1) {
+                    $shows->orderBy($sort[0]);
+                } else {
+                    $shows->orderBy($sort[0], $sort[1]);
+                }
+            }
+        } else {
+            $shows->orderBy('start_date');
+        }
+
+
+        /**
+         * If the query parameter "per_page" is set,
+         * it should return the given amount of shows per page.
+         * If "per_page" isn't set, it should return 25 shows per page, maximum 50.
+         */
+        if (isset($validated['per_page']) && $validated['per_page'] <= 50) {
+            $res = $shows->paginate($validated['per_page']);
+        } else {
+            $res = $shows->paginate(25);
+        }
+
+        return ShowResource::collection($res);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Show $show)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Show $show)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Show $show)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/ShowController.php
+++ b/app/Http/Controllers/ShowController.php
@@ -10,6 +10,8 @@ use App\Models\User;
 use App\Permissions\ShowsPermissions;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Routing\Controllers\Middleware;
+use Spatie\Permission\Middleware\PermissionMiddleware;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ShowController extends Controller
@@ -64,19 +66,16 @@ class ShowController extends Controller
     }
 
     /**
-     * ShowController constructor.
-     *
-     * This method initializes the ShowController class.
-     * It sets up the necessary middleware for specific actions.
+     * Return the middleware configurations for the controller.
+     * @return Middleware[]
      */
-    public function __construct()
+    public function middleware(): array
     {
-        $this->middleware('permission:' . ShowsPermissions::CAN_CREATE_SHOWS . '|' . ShowsPermissions::CAN_CREATE_SHOWS_OTHERS)
-            ->only(['store']);
-        $this->middleware('permission:' . ShowsPermissions::CAN_UPDATE_SHOWS . '|' . ShowsPermissions::CAN_UPDATE_SHOWS_OTHERS)
-            ->only(['update']);
-        $this->middleware('permission:' . ShowsPermissions::CAN_DELETE_SHOWS . '|' . ShowsPermissions::CAN_DELETE_SHOWS_OTHERS)
-            ->only(['delete']);
+        return [
+            new Middleware(PermissionMiddleware::using([ShowsPermissions::CAN_CREATE_SHOWS, ShowsPermissions::CAN_CREATE_SHOWS_OTHERS]), only: ['store']),
+            new Middleware(PermissionMiddleware::using([ShowsPermissions::CAN_UPDATE_SHOWS, ShowsPermissions::CAN_UPDATE_SHOWS_OTHERS]), only: ['update']),
+            new Middleware(PermissionMiddleware::using([ShowsPermissions::CAN_DELETE_SHOWS, ShowsPermissions::CAN_DELETE_SHOWS_OTHERS]), only: ['delete']),
+        ];
     }
 
     /**

--- a/app/Http/Resources/ShowResource.php
+++ b/app/Http/Resources/ShowResource.php
@@ -20,7 +20,7 @@ class ShowResource extends JsonResource
             return [
                 'id' => $moderator->id,
                 'name' => $moderator->name,
-                'primary' => $moderator->moderators->primary,
+                'primary' => $moderator->moderators->primary === 1,
             ];
         });
 

--- a/app/Http/Resources/ShowResource.php
+++ b/app/Http/Resources/ShowResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ShowResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $show = parent::toArray($request);
+
+        $show['moderators'] = $this->moderators->map(function ($moderator) {
+            return [
+                'id' => $moderator->id,
+                'name' => $moderator->name,
+                'primary' => $moderator->moderators->primary,
+            ];
+        });
+
+        return $show;
+    }
+}

--- a/app/Models/Show.php
+++ b/app/Models/Show.php
@@ -15,6 +15,10 @@ class Show extends Model
      * @var array<int, string>
      */
     protected $fillable = [
+        'title',
+        'body',
+        'enabled',
+        'is_live',
     ];
 
     /**
@@ -31,6 +35,10 @@ class Show extends Model
      * @var array<string, string>
      */
     protected $casts = [
+        'start_date' => 'datetime',
+        'end_date' => 'datetime',
+        'enabled' => 'boolean',
+        'is_live' => 'boolean',
     ];
 
     public function locked_by()

--- a/app/Models/Show.php
+++ b/app/Models/Show.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Show extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = [
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+    ];
+
+    public function locked_by()
+    {
+        return $this->belongsTo(User::class, 'locked_by');
+    }
+
+    public function moderators()
+    {
+        return $this->belongsToMany(User::class, 'show_moderators', 'show_id', 'moderator_id')->as('moderators')->withTimestamps();
+    }
+
+    public function primary_moderator()
+    {
+        return $this->belongsToMany(User::class, 'show_moderators', 'show_id', 'moderator_id')->wherePivot('primary', true);
+    }
+}

--- a/app/Models/Show.php
+++ b/app/Models/Show.php
@@ -48,7 +48,10 @@ class Show extends Model
 
     public function moderators()
     {
-        return $this->belongsToMany(User::class, 'show_moderators', 'show_id', 'moderator_id')->as('moderators')->withTimestamps();
+        return $this->belongsToMany(User::class, 'show_moderators', 'show_id', 'moderator_id')
+            ->withPivot('primary')
+            ->as('moderators')
+            ->withTimestamps();
     }
 
     public function primary_moderator()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -46,4 +46,14 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    public function locked_shows()
+    {
+        return $this->hasMany(Show::class, 'locked_by');
+    }
+
+    // public function shows()
+    // {
+    //     return $this->belongsToMany(Show::class, 'show_moderators', 'moderator_id', 'show_id')->withTimestamps();
+    // }
 }

--- a/app/Permissions/ShowsPermissions.php
+++ b/app/Permissions/ShowsPermissions.php
@@ -10,7 +10,7 @@ namespace App\Permissions;
 class ShowsPermissions
 {
     /** Permission for viewing others disabled shows. */
-    public const CAN_VIEW_DISABLED_SHOWS_OTHERS = 'shows.view-disabled.others';
+    public const CAN_VIEW_DISABLED_SHOWS_OTHERS = 'shows.view.disabled.others';
 
     /** Permission for creating own shows as primary moderator. */
     public const CAN_CREATE_SHOWS = 'shows.create';
@@ -31,7 +31,7 @@ class ShowsPermissions
     public const CAN_DELETE_SHOWS_OTHERS = 'shows.delete.others';
 
     /** Permission to be primary moderator of a show. */
-    public const CAN_BE_PRIMARY_MODERATOR = 'shows.be-primary-moderator';
+    public const CAN_BE_PRIMARY_MODERATOR = 'shows.be-moderator.primary';
 
     /** Permission for adding non-primary moderators to a show. */
     public const CAN_ADD_MODERATORS = 'shows.add-moderators';

--- a/app/Permissions/ShowsPermissions.php
+++ b/app/Permissions/ShowsPermissions.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Permissions;
+
+/**
+ * Class ShowsPermissions
+ *
+ * This class defines the permissions related to shows.
+ */
+class ShowsPermissions
+{
+    /** Permission for viewing others disabled shows. */
+    public const CAN_VIEW_DISABLED_SHOWS_OTHERS = 'view-disabled-shows-others';
+
+    /** Permission for creating own shows as primary moderator. */
+    public const CAN_CREATE_SHOWS = 'create-shows';
+
+    /** Permission for creating shows for others as primary moderator. */
+    public const CAN_CREATE_SHOWS_OTHERS = 'create-shows-others';
+
+    /** Permission for updating own shows when primary moderator. */
+    public const CAN_UPDATE_SHOWS = 'update-shows';
+
+    /** Permission for updating shows for others. */
+    public const CAN_UPDATE_SHOWS_OTHERS = 'update-shows-others';
+
+    /** Permission for deleting own shows when primary moderator. */
+    public const CAN_DELETE_SHOWS = 'delete-shows';
+
+    /** Permission for deleting shows for others. */
+    public const CAN_DELETE_SHOWS_OTHERS = 'delete-shows-others';
+
+    /** Permission for to be primary moderator of a show. */
+    public const CAN_BE_PRIMARY_MODERATOR = 'primary-moderator-shows';
+
+    /** Permission for to be moderator of a show. */
+    public const CAN_BE_MODERATOR = 'moderator-shows';
+
+    /** Permission to change a show's live status. */
+    public const CAN_SET_LIVE_SHOWS = 'set-live-shows';
+
+    /** Permission to enable or disable a show. */
+    public const CAN_ENABLE_SHOWS = 'enable-shows';
+}

--- a/app/Permissions/ShowsPermissions.php
+++ b/app/Permissions/ShowsPermissions.php
@@ -10,35 +10,38 @@ namespace App\Permissions;
 class ShowsPermissions
 {
     /** Permission for viewing others disabled shows. */
-    public const CAN_VIEW_DISABLED_SHOWS_OTHERS = 'view-disabled-shows-others';
+    public const CAN_VIEW_DISABLED_SHOWS_OTHERS = 'shows.view-disabled.others';
 
     /** Permission for creating own shows as primary moderator. */
-    public const CAN_CREATE_SHOWS = 'create-shows';
+    public const CAN_CREATE_SHOWS = 'shows.create';
 
     /** Permission for creating shows for others as primary moderator. */
-    public const CAN_CREATE_SHOWS_OTHERS = 'create-shows-others';
+    public const CAN_CREATE_SHOWS_OTHERS = 'shows.create.others';
 
     /** Permission for updating own shows when primary moderator. */
-    public const CAN_UPDATE_SHOWS = 'update-shows';
+    public const CAN_UPDATE_SHOWS = 'shows.update';
 
     /** Permission for updating shows for others. */
-    public const CAN_UPDATE_SHOWS_OTHERS = 'update-shows-others';
+    public const CAN_UPDATE_SHOWS_OTHERS = 'shows.update.others';
 
     /** Permission for deleting own shows when primary moderator. */
-    public const CAN_DELETE_SHOWS = 'delete-shows';
+    public const CAN_DELETE_SHOWS = 'shows.delete';
 
     /** Permission for deleting shows for others. */
-    public const CAN_DELETE_SHOWS_OTHERS = 'delete-shows-others';
+    public const CAN_DELETE_SHOWS_OTHERS = 'shows.delete.others';
 
-    /** Permission for to be primary moderator of a show. */
-    public const CAN_BE_PRIMARY_MODERATOR = 'primary-moderator-shows';
+    /** Permission to be primary moderator of a show. */
+    public const CAN_BE_PRIMARY_MODERATOR = 'shows.be-primary-moderator';
 
-    /** Permission for to be moderator of a show. */
-    public const CAN_BE_MODERATOR = 'moderator-shows';
+    /** Permission for adding non-primary moderators to a show. */
+    public const CAN_ADD_MODERATORS = 'shows.add-moderators';
+
+    /** Permission to be moderator of a show, but not primary . */
+    public const CAN_BE_MODERATOR = 'shows.be-moderator';
 
     /** Permission to change a show's live status. */
-    public const CAN_SET_LIVE_SHOWS = 'set-live-shows';
+    public const CAN_SET_LIVE_SHOWS = 'shows.set-live';
 
     /** Permission to enable or disable a show. */
-    public const CAN_ENABLE_SHOWS = 'enable-shows';
+    public const CAN_ENABLE_SHOWS = 'shows.enable';
 }

--- a/database/factories/ShowFactory.php
+++ b/database/factories/ShowFactory.php
@@ -37,6 +37,12 @@ class ShowFactory extends Factory
         ];
     }
 
+    /**
+     * Add a user to the show and set it as primary.
+     * Add a random number of users to the show, which are not already added.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
     public function withUser()
     {
         return $this->afterCreating(function (Show $show) {

--- a/database/factories/ShowFactory.php
+++ b/database/factories/ShowFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Show;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Show>
+ */
+class ShowFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        do {
+
+            $start_date = $this->faker->dateTimeBetween('-2 days', '+1 month');
+            $end_date = $this->faker->dateTimeBetween($start_date, (clone $start_date)->modify('+48 hours'));
+
+            $show = Show::where('start_date', '<=', $end_date)->where('end_date', '>=', $start_date)->first();
+        } while ($show !== null);
+
+        return [
+            'title' => $this->faker->sentence(),
+            'body' => $this->faker->paragraph(),
+            'start_date' => $start_date,
+            'end_date' => $end_date,
+            'is_live' => $this->faker->boolean(),
+            'enabled' => $this->faker->boolean(),
+            'locked_by' => $this->faker->randomElement([null, User::all()->random()->id ?? User::factory()->create()->id])
+        ];
+    }
+
+    public function withUser()
+    {
+        return $this->afterCreating(function (Show $show) {
+            // Add a user to the show and set it as primary.
+            $show->moderators()->attach(User::all()->random()->id ?? User::factory()->create()->id, ['primary' => true]);
+
+            // Add a random number of users to the show. Which are not already added.
+            $show->moderators()->attach(User::all()->random()->pluck('id')->diff($show->moderators()->pluck('moderator_id')), ['primary' => false]);
+        });
+    }
+}

--- a/database/migrations/2023_12_20_221341_create_shows_table.php
+++ b/database/migrations/2023_12_20_221341_create_shows_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('shows', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('body')->nullable();
+            $table->dateTime('start_date')->index()->comment('The date the show starts');
+            $table->dateTime('end_date')->index()->comment('The date the show ends');
+            $table->boolean('is_live');
+            $table->boolean('enabled');
+            $table->unsignedBigInteger('locked_by')->nullable()->comment('The user who locked the show');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('shows');
+    }
+};

--- a/database/migrations/2023_12_20_223036_create_show_moderators_pivot_table.php
+++ b/database/migrations/2023_12_20_223036_create_show_moderators_pivot_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('show_moderators', function (Blueprint $table) {
+            $table->unsignedBigInteger('show_id');
+            $table->unsignedBigInteger('moderator_id');
+            $table->boolean('primary');
+            $table->timestamps();
+            $table->primary(['show_id', 'moderator_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('show_moderators');
+    }
+};

--- a/database/migrations/2023_12_28_223745_add_show_permissions.php
+++ b/database/migrations/2023_12_28_223745_add_show_permissions.php
@@ -1,0 +1,84 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Spatie\Permission\Models\Permission;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Permission::create([
+            'name' => 'shows.view-disabled.others',
+            'guard_name' => 'web',
+        ]);
+        Permission::create([
+            'name' => 'shows.create',
+            'guard_name' => 'web',
+        ]);
+        Permission::create([
+            'name' => 'shows.create.others',
+            'guard_name' => 'web',
+        ]);
+        Permission::create([
+            'name' => 'shows.update',
+            'guard_name' => 'web',
+        ]);
+        Permission::create([
+            'name' => 'shows.update.others',
+            'guard_name' => 'web',
+        ]);
+        Permission::create([
+            'name' => 'shows.delete',
+            'guard_name' => 'web',
+        ]);
+        Permission::create([
+            'name' => 'shows.delete.others',
+            'guard_name' => 'web',
+        ]);
+        Permission::create([
+            'name' => 'shows.be-primary-moderator',
+            'guard_name' => 'web',
+        ]);
+        Permission::create([
+            'name' => 'shows.be-moderator',
+            'guard_name' => 'web',
+        ]);
+        Permission::create([
+            'name' => 'shows.add-moderators',
+            'guard_name' => 'web',
+        ]);
+        Permission::create([
+            'name' => 'shows.set-live',
+            'guard_name' => 'web',
+        ]);
+        Permission::create([
+            'name' => 'shows.enable',
+            'guard_name' => 'web',
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('permissions')->whereIn('name', [
+            'shows.view-disabled.others',
+            'shows.create',
+            'shows.create.others',
+            'shows.update',
+            'shows.update.others',
+            'shows.delete',
+            'shows.delete.others',
+            'shows.be-primary-moderator',
+            'shows.be-moderator',
+            'shows.add-moderators',
+            'shows.set-live',
+            'shows.enable',
+        ])->delete();
+    }
+};

--- a/database/migrations/2023_12_28_223745_add_show_permissions.php
+++ b/database/migrations/2023_12_28_223745_add_show_permissions.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Permission::create([
-            'name' => 'shows.view-disabled.others',
+            'name' => 'shows.view.disabled.others',
             'guard_name' => 'web',
         ]);
         Permission::create([
@@ -40,7 +40,7 @@ return new class extends Migration
             'guard_name' => 'web',
         ]);
         Permission::create([
-            'name' => 'shows.be-primary-moderator',
+            'name' => 'shows.be-moderator.primary',
             'guard_name' => 'web',
         ]);
         Permission::create([

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,5 +20,16 @@ class DatabaseSeeder extends Seeder
         //     'email_verified_at' => now(),
         //     'password' => bcrypt('test1234'),
         // ]);
+
+        \App\Models\User::factory(30)->create();
+
+        \App\Models\Show::factory(10)->create([
+            'enabled' => true,
+        ])->each(function ($show) {
+            $show->moderators()->attach(\App\Models\User::all()->random()->id ?? \App\Models\User::factory()->create()->id, ['primary' => true]);
+
+            // Add a random number of users to the show. Which are not already added.
+            $show->moderators()->attach(\App\Models\User::all()->random(rand(0, 10))->pluck('id')->diff($show->moderators()->pluck('moderator_id')), ['primary' => false]);
+        });
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,4 +26,5 @@ Route::group(['prefix' => 'v1'], function () {
     require __DIR__ . '/api/v1/role.php';
     require __DIR__ . '/api/v1/request.php';
     require __DIR__ . '/api/v1/permission.php';
+    require __DIR__ . '/api/v1/show.php';
 });

--- a/routes/api/v1/show.php
+++ b/routes/api/v1/show.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Http\Controllers\ShowController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/shows', [ShowController::class, 'index'])->name('api.v1.shows.index');
+Route::post('/shows', [ShowController::class, 'store'])->name('api.v1.shows.store');
+Route::get('/shows/{show}', [ShowController::class, 'show'])->name('api.v1.shows.show');
+Route::put('/shows/{show}', [ShowController::class, 'update'])->name('api.v1.shows.update');
+Route::delete('/shows/{show}', [ShowController::class, 'destroy'])->name('api.v1.shows.destroy');
+

--- a/routes/api/v1/show.php
+++ b/routes/api/v1/show.php
@@ -9,3 +9,9 @@ Route::get('/shows/{show}', [ShowController::class, 'show'])->name('api.v1.shows
 Route::put('/shows/{show}', [ShowController::class, 'update'])->name('api.v1.shows.update');
 Route::delete('/shows/{show}', [ShowController::class, 'destroy'])->name('api.v1.shows.destroy');
 
+Route::group(['middleware' => ['auth:sanctum']], function () {
+    Route::post('/shows', [ShowController::class, 'store'])->name('api.v1.shows.store');
+    Route::put('/shows/{show}', [ShowController::class, 'update'])->name('api.v1.shows.update');
+    Route::delete('/shows/{show}', [ShowController::class, 'destroy'])->name('api.v1.shows.destroy');
+});
+

--- a/tests/Feature/Http/Controllers/ShowControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShowControllerTest.php
@@ -65,17 +65,24 @@ class ShowControllerTest extends TestCase
             ],
         ]);
 
-        // Sort the shows by start date and take the first 5
-        $shows = $shows->sortBy('start_date')->values()->take($perPage);
+        $sortedShows = $shows->sortBy('start_date');
+
+        $sortedShows->values()->all();
+
+        // remove shows where the end or start date is not within the range
+        $sortedShows = $sortedShows->filter(function ($show) use ($today, $inAMonth) {
+            return $show->start_date->isBetween($today, $inAMonth) || $show->end_date->isBetween($today, $inAMonth);
+        });
+
 
         // Assert that the response contains the correct show data
         $response->assertJsonFragment([
-            'id' => $shows->first()->id,
-            'title' => $shows->first()->title,
-            'start_date' => $shows->first()->start_date,
-            'end_date' => $shows->first()->end_date,
-            'is_live' => $shows->first()->is_live,
-            'enabled' => $shows->first()->enabled,
+            'id' => $sortedShows->first()->id,
+            'title' => $sortedShows->first()->title,
+            'start_date' => $sortedShows->first()->start_date,
+            'end_date' => $sortedShows->first()->end_date,
+            'is_live' => $sortedShows->first()->is_live,
+            'enabled' => $sortedShows->first()->enabled,
         ]);
     }
 }

--- a/tests/Feature/Http/Controllers/ShowControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShowControllerTest.php
@@ -3,9 +3,14 @@
 namespace Tests\Feature\Http\Controllers;
 
 use App\Models\Show;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Testing\TestResponse;
 use Tests\TestCase;
 
+/**
+ * @coversDefaultClass \App\Http\Controllers\ShowController
+ */
 class ShowControllerTest extends TestCase
 {
     use RefreshDatabase;
@@ -13,21 +18,31 @@ class ShowControllerTest extends TestCase
     /**
      * Test retrieving a paginated list of shows.
      *
+     * @covers ::index
      * @return void
      */
-    public function testIndex(): void
+    public function test_index(): void
     {
+        // Create some test user
+        User::factory()->count(30)->create();
+
         // Create some test data
-        $shows = Show::factory()->count(5)->create();
+        $shows = Show::factory([
+            'enabled' => true,
+        ])->withUser()->count(10)->create();
+
+        $today = today();
+        $inAMonth = today()->addMonth();
+        $perPage = 5;
 
         // Make a GET request to the index endpoint
-        $response = $this->get('/api/v1/shows');
+        $response = $this->getJson('/api/v1/shows?start_date=' . $today . '&end_date=' . $inAMonth . '&per_page=' . $perPage);
 
         // Assert that the response has a successful status code
         $response->assertStatus(200);
 
         // Assert that the response contains the correct number of shows
-        $response->assertJsonCount(5, 'data');
+        $response->assertJsonCount($perPage, 'data');
 
         // Assert that the response contains the correct show data
         $response->assertJsonStructure([
@@ -37,7 +52,7 @@ class ShowControllerTest extends TestCase
                     'title',
                     'start_date',
                     'end_date',
-                    'live',
+                    'is_live',
                     'enabled',
                     'moderators' => [
                         '*' => [
@@ -48,6 +63,19 @@ class ShowControllerTest extends TestCase
                     ],
                 ],
             ],
+        ]);
+
+        // Sort the shows by start date and take the first 5
+        $shows = $shows->sortBy('start_date')->values()->take($perPage);
+
+        // Assert that the response contains the correct show data
+        $response->assertJsonFragment([
+            'id' => $shows->first()->id,
+            'title' => $shows->first()->title,
+            'start_date' => $shows->first()->start_date,
+            'end_date' => $shows->first()->end_date,
+            'is_live' => $shows->first()->is_live,
+            'enabled' => $shows->first()->enabled,
         ]);
     }
 }

--- a/tests/Feature/Http/Controllers/ShowControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShowControllerTest.php
@@ -2,19 +2,52 @@
 
 namespace Tests\Feature\Http\Controllers;
 
+use App\Models\Show;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class ShowControllerTest extends TestCase
 {
+    use RefreshDatabase;
+
     /**
-     * A basic feature test example.
+     * Test retrieving a paginated list of shows.
+     *
+     * @return void
      */
-    public function test_example(): void
+    public function testIndex(): void
     {
+        // Create some test data
+        $shows = Show::factory()->count(5)->create();
+
+        // Make a GET request to the index endpoint
         $response = $this->get('/api/v1/shows');
 
+        // Assert that the response has a successful status code
         $response->assertStatus(200);
+
+        // Assert that the response contains the correct number of shows
+        $response->assertJsonCount(5, 'data');
+
+        // Assert that the response contains the correct show data
+        $response->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'title',
+                    'start_date',
+                    'end_date',
+                    'live',
+                    'enabled',
+                    'moderators' => [
+                        '*' => [
+                            'id',
+                            'name',
+                            'primary',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
     }
 }

--- a/tests/Feature/Http/Controllers/ShowControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShowControllerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class ShowControllerTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     */
+    public function test_example(): void
+    {
+        $response = $this->get('/api/v1/shows');
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
Implement Show Model and corresponding CRUD REST API Endpoints. Restrict access based on user authentication status; if the user is not logged in, limit access to shows within the current day until one month later.

Check for overlaps with existing shows for new and updated shows, taking into account the enabled status of existing shows to prevent conflicts. Implement permissions and checks for secure CRUD operations based on user roles and authentication status.

Ensure comprehensive test coverage for creating, updating, and deleting shows. Test access restrictions based on user authentication and permissions.

---

- Close: #22
- Close: #2
- Close: #3
- Close: #4 
- Close: #5 
- Close: #6 

refactor: rename `swagger.yml` to `openapi.yml`