### PR TITLE
refactor(role): update naming and creation process

### DIFF
--- a/app/Permissions/RolesPermissions.php
+++ b/app/Permissions/RolesPermissions.php
@@ -10,14 +10,14 @@ namespace App\Permissions;
 class RolesPermissions
 {
     /** Permission for showing roles. */
-    public const CAN_SHOW_ROLES = 'show-roles';
+    public const CAN_SHOW_ROLES = 'roles.show';
 
     /** Permission for creating users. */
-    public const CAN_CREATE_ROLES = 'create-roles';
+    public const CAN_CREATE_ROLES = 'roles.create';
 
     /** Permission for updating users. */
-    public const CAN_UPDATE_ROLES = 'update-roles';
+    public const CAN_UPDATE_ROLES = 'roles.update';
 
     /** Permission for deleting users. */
-    public const CAN_DELETE_ROLES = 'delete-roles';
+    public const CAN_DELETE_ROLES = 'roles.delete';
 }

--- a/database/migrations/2023_12_14_193625_add_roles_permissions.php
+++ b/database/migrations/2023_12_14_193625_add_roles_permissions.php
@@ -3,6 +3,7 @@
 use App\Permissions\RolesPermissions;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
+use Spatie\Permission\Models\Permission;
 
 return new class extends Migration
 {
@@ -11,31 +12,21 @@ return new class extends Migration
      */
     public function up(): void
     {
-        DB::table('permissions')->insert([
-            [
-                'name' => RolesPermissions::CAN_SHOW_ROLES,
-                'guard_name' => 'web',
-                'created_at' => now(),
-                'updated_at' => now(),
-            ],
-            [
-                'name' => RolesPermissions::CAN_CREATE_ROLES,
-                'guard_name' => 'web',
-                'created_at' => now(),
-                'updated_at' => now(),
-            ],
-            [
-                'name' => RolesPermissions::CAN_UPDATE_ROLES,
-                'guard_name' => 'web',
-                'created_at' => now(),
-                'updated_at' => now(),
-            ],
-            [
-                'name' => RolesPermissions::CAN_DELETE_ROLES,
-                'guard_name' => 'web',
-                'created_at' => now(),
-                'updated_at' => now(),
-            ],
+        Permission::create([
+            'name' => 'roles.show',
+            'guard_name' => 'web',
+        ]);
+        Permission::create([
+            'name' => 'roles.create',
+            'guard_name' => 'web',
+        ]);
+        Permission::create([
+            'name' => 'roles.update',
+            'guard_name' => 'web',
+        ]);
+        Permission::create([
+            'name' => 'roles.delete',
+            'guard_name' => 'web',
         ]);
     }
 
@@ -45,10 +36,10 @@ return new class extends Migration
     public function down(): void
     {
         DB::table('permissions')->whereIn('name', [
-            RolesPermissions::CAN_SHOW_ROLES,
-            RolesPermissions::CAN_CREATE_ROLES,
-            RolesPermissions::CAN_UPDATE_ROLES,
-            RolesPermissions::CAN_DELETE_ROLES,
+            'roles.show',
+            'roles.create',
+            'roles.update',
+            'roles.delete',
         ])->delete();
     }
 };


### PR DESCRIPTION
Improve codebase clarity by adopting dot notation for role permissions' naming and utilizing the models create function for permission creation.