### PR TITLE
feat(request): implement Wishbox request model and API endpoints

### DIFF
--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -4,14 +4,23 @@ namespace App\Http\Controllers;
 
 use App\Http\Responses\ApiErrorResponse;
 use App\Http\Responses\ApiSuccessResponse;
-use App\Models\Request;
+use App\Models\Request as WishRequest;
 use App\Permissions\RequestPermissions;
-use Illuminate\Http\Request as HttpRequest;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 
 class RequestController extends Controller
 {
 
+
+    /**
+     * Constructor method for the RequestController class.
+     * Applies middleware permissions for specific controller actions.
+     *
+     * @codeCoverageIgnore
+     *
+     * @return void
+     */
     public function __construct()
     {
         $this->middleware('permission:' . RequestPermissions::CAN_VIEW_REQUESTS)->only(['index', 'show']);
@@ -21,10 +30,10 @@ class RequestController extends Controller
     /**
      * Retrieve a paginated list of requests.
      *
-     * @param  HttpRequest  $httpRequest
+     * @param  Request  $httpRequest
      * @return \Illuminate\Pagination\LengthAwarePaginator
      */
-    public function index(HttpRequest $httpRequest): \Illuminate\Pagination\LengthAwarePaginator
+    public function index(Request $httpRequest): \Illuminate\Pagination\LengthAwarePaginator
     {
         $httpRequest->validate([
             'sort' => 'string|in:id,id:asc,id:desc,name,name:asc,name:desc,created_at,created_at:asc,created_at:desc,',
@@ -33,9 +42,9 @@ class RequestController extends Controller
 
         if ($httpRequest->sort !== null) {
             $sort = explode(':', $httpRequest->sort);
-            $requests = Request::orderBy($sort[0], $sort[1] ?? 'asc')->paginate($httpRequest->per_page ?? 25);
+            $requests = WishRequest::orderBy($sort[0], $sort[1] ?? 'asc')->paginate($httpRequest->per_page ?? 25);
         } else {
-            $requests = Request::orderBy('created_at')->paginate($httpRequest->per_page ?? 25);
+            $requests = WishRequest::orderBy('created_at')->paginate($httpRequest->per_page ?? 25);
         }
 
         return $requests;
@@ -44,20 +53,22 @@ class RequestController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(HttpRequest $httpRequest)
+    public function store(Request $httpRequest)
     {
         $httpRequest->validate([
             'name' => 'required|string|max:255',
             'message' => 'required|string',
         ]);
 
-        $request = Request::create([
+        $request = WishRequest::create([
             'name' => $httpRequest->name,
             'message' => $httpRequest->message,
         ]);
 
         if ($request === null) {
+            // @codeCoverageIgnoreStart
             return new ApiErrorResponse('Failed to create request');
+            // @codeCoverageIgnoreEnd
         } else {
             return new ApiSuccessResponse($request, status: Response::HTTP_CREATED);
         }
@@ -66,7 +77,7 @@ class RequestController extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(Request $request)
+    public function show(WishRequest $request)
     {
         return new ApiSuccessResponse($request);
     }
@@ -74,12 +85,14 @@ class RequestController extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Request $request)
+    public function destroy(WishRequest $request)
     {
         if($request->delete()) {
             return new ApiSuccessResponse('', status: Response::HTTP_NO_CONTENT);
         } else {
+            // @codeCoverageIgnoreStart
             return new ApiErrorResponse('Failed to delete');
+            // @codeCoverageIgnoreEnd
         }
     }
 }

--- a/app/Http/Controllers/RequestController.php
+++ b/app/Http/Controllers/RequestController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Responses\ApiErrorResponse;
+use App\Http\Responses\ApiSuccessResponse;
+use App\Models\Request;
+use App\Permissions\RequestPermissions;
+use Illuminate\Http\Request as HttpRequest;
+use Illuminate\Http\Response;
+
+class RequestController extends Controller
+{
+
+    public function __construct()
+    {
+        $this->middleware('permission:' . RequestPermissions::CAN_VIEW_REQUESTS)->only(['index', 'show']);
+        $this->middleware('permission:' . RequestPermissions::CAN_DELETE_REQUESTS)->only(['destroy']);
+    }
+
+    /**
+     * Retrieve a paginated list of requests.
+     *
+     * @param  HttpRequest  $httpRequest
+     * @return \Illuminate\Pagination\LengthAwarePaginator
+     */
+    public function index(HttpRequest $httpRequest): \Illuminate\Pagination\LengthAwarePaginator
+    {
+        $httpRequest->validate([
+            'sort' => 'string|in:id,id:asc,id:desc,name,name:asc,name:desc,created_at,created_at:asc,created_at:desc,',
+            'per_page' => 'integer|between:1,50',
+        ]);
+
+        if ($httpRequest->sort !== null) {
+            $sort = explode(':', $httpRequest->sort);
+            $requests = Request::orderBy($sort[0], $sort[1] ?? 'asc')->paginate($httpRequest->per_page ?? 25);
+        } else {
+            $requests = Request::orderBy('created_at')->paginate($httpRequest->per_page ?? 25);
+        }
+
+        return $requests;
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(HttpRequest $httpRequest)
+    {
+        $httpRequest->validate([
+            'name' => 'required|string|max:255',
+            'message' => 'required|string',
+        ]);
+
+        $request = Request::create([
+            'name' => $httpRequest->name,
+            'message' => $httpRequest->message,
+        ]);
+
+        if ($request === null) {
+            return new ApiErrorResponse('Failed to create request');
+        } else {
+            return new ApiSuccessResponse($request, status: Response::HTTP_CREATED);
+        }
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Request $request)
+    {
+        return new ApiSuccessResponse($request);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Request $request)
+    {
+        if($request->delete()) {
+            return new ApiSuccessResponse('', status: Response::HTTP_NO_CONTENT);
+        } else {
+            return new ApiErrorResponse('Failed to delete');
+        }
+    }
+}

--- a/app/Models/Request.php
+++ b/app/Models/Request.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Request extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+        'message',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = [
+        'updated_at',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+}

--- a/app/Permissions/RequestPermissions.php
+++ b/app/Permissions/RequestPermissions.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Permissions;
+
+/**
+ * Class RequestPermissions
+ *
+ * This class defines the permissions related to requests.
+ */
+class RequestPermissions
+{
+    /** Permission for listing and view all users. */
+    public const CAN_VIEW_REQUESTS = 'requests.view';
+
+    /** Permission for deleting users. */
+    public const CAN_DELETE_REQUESTS = 'requests.delete';
+}

--- a/database/factories/RequestFactory.php
+++ b/database/factories/RequestFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Request>
+ */
+class RequestFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->name,
+            'message' => $this->faker->paragraph()
+        ];
+    }
+}

--- a/database/migrations/2023_12_29_205859_create_requests_table.php
+++ b/database/migrations/2023_12_29_205859_create_requests_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('requests', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('message')->max(2000);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('requests');
+    }
+};

--- a/database/migrations/2023_12_29_212656_add_request_permissions.php
+++ b/database/migrations/2023_12_29_212656_add_request_permissions.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Spatie\Permission\Models\Permission;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Permission::create([
+            'name' => 'requests.view',
+            'guard_name' => 'web',
+        ]);
+        Permission::create([
+            'name' => 'requests.delete',
+            'guard_name' => 'web',
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('permissions')->whereIn('name', [
+            'requests.view',
+            'requests.delete',
+        ])->delete();
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,4 +24,5 @@ Route::group(['prefix' => 'v1'], function () {
     require __DIR__ . '/api/v1/auth.php';
     require __DIR__ . '/api/v1/user.php';
     require __DIR__ . '/api/v1/role.php';
+    require __DIR__ . '/api/v1/request.php';
 });

--- a/routes/api/v1/request.php
+++ b/routes/api/v1/request.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Http\Controllers\RequestController;
+use Illuminate\Support\Facades\Route;
+
+
+Route::post('/requests', [RequestController::class, 'store'])->name('api.v1.requests.store');
+
+Route::group(['middleware' => 'auth:sanctum'], function () {
+    Route::get('/requests', [RequestController::class, 'index'])->name('api.v1.requests.index');
+    Route::get('/requests/{request}', [RequestController::class, 'show'])->name('api.v1.requests.show');
+    Route::delete('/requests/{request}', [RequestController::class, 'destroy'])->name('api.v1.requests.destroy');
+});

--- a/tests/Feature/Http/Controllers/RequestControllerTest.php
+++ b/tests/Feature/Http/Controllers/RequestControllerTest.php
@@ -89,6 +89,36 @@ class RequestControllerTest extends TestCase
 
         $response->assertStatus(200);
 
+        $response->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'name',
+                    'message',
+                    'created_at',
+                ],
+            ],
+            'links' => [
+                '*' => [
+                    'url',
+                    'label',
+                    'active',
+                ],
+            ],
+            'first_page_url',
+            'from',
+            'last_page',
+            'last_page_url',
+            'next_page_url',
+            'path',
+            'per_page',
+            'prev_page_url',
+            'to',
+            'total',
+        ]);
+
+        $testReq = $testReq->sortByDesc('id')->values()->take(5);
+
         $response->assertJsonFragment([
             'id' => $testReq[0]->id,
             'name' => $testReq[0]->name,

--- a/tests/Feature/Http/Controllers/RequestControllerTest.php
+++ b/tests/Feature/Http/Controllers/RequestControllerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Models\Request;
+use App\Models\User;
+use App\Permissions\RequestPermissions;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Response;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * @coversDefaultClass \App\Http\Controllers\RequestController
+ */
+class RequestControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test retrieving a paginated list of requests.
+     *
+     * @covers ::index
+     */
+    public function test_list_requests(): void
+    {
+        $testReq = Request::factory()->count(10)->create();
+
+        Sanctum::actingAs(User::factory()->create()->givePermissionTo([
+            RequestPermissions::CAN_VIEW_REQUESTS,
+        ])
+        );
+
+        $response = $this->getJson('/api/v1/requests');
+
+        $response->assertStatus(200);
+
+        $response->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'name',
+                    'message',
+                    'created_at',
+                ],
+            ],
+            'links' => [
+                '*' => [
+                    'url',
+                    'label',
+                    'active',
+                ],
+            ],
+            'first_page_url',
+            'from',
+            'last_page',
+            'last_page_url',
+            'next_page_url',
+            'path',
+            'per_page',
+            'prev_page_url',
+            'to',
+            'total',
+        ]);
+
+        $response->assertJsonFragment([
+            'id' => $testReq[0]->id,
+            'name' => $testReq[0]->name,
+            'message' => $testReq[0]->message,
+            'created_at' => $testReq[0]->created_at,
+        ]);
+    }
+
+    /**
+     * Test retrieving a paginated list of requests with sorting.
+     *
+     * @covers ::index
+     */
+    public function test_list_requests_with_sorting(): void
+    {
+        $testReq = Request::factory()->count(10)->create();
+
+        Sanctum::actingAs(User::factory()->create()->givePermissionTo([
+            RequestPermissions::CAN_VIEW_REQUESTS,
+        ])
+        );
+
+        $response = $this->getJson('/api/v1/requests?sort=id:desc&per_page=5');
+
+        $response->assertStatus(200);
+
+        $response->assertJsonFragment([
+            'id' => $testReq[0]->id,
+            'name' => $testReq[0]->name,
+            'message' => $testReq[0]->message,
+            'created_at' => $testReq[0]->created_at,
+        ]);
+    }
+
+    /**
+     * Test storing a newly created request.
+     *
+     * @covers ::store
+     */
+    public function test_store_request(): void
+    {
+        $data = [
+            'name' => 'Test Request',
+            'message' => 'This is a test request.',
+        ];
+
+        $response = $this->postJson('/api/v1/requests', $data);
+
+        $this->assertDatabaseHas('requests', [
+            'name' => $data['name'],
+            'message' => $data['message'],
+        ]);
+
+        $response->assertStatus(Response::HTTP_CREATED);
+
+        $response->assertJsonFragment([
+            'name' => $data['name'],
+            'message' => $data['message'],
+        ]);
+    }
+
+    /**
+     * Test displaying a specific request.
+     *
+     * @covers ::show
+     */
+    public function test_show_single_request(): void
+    {
+        $request = Request::factory(5)->create();
+
+        Sanctum::actingAs(User::factory()->create()->givePermissionTo([
+            RequestPermissions::CAN_VIEW_REQUESTS,
+        ])
+        );
+
+        $response = $this->getJson('/api/v1/requests/'.$request->get(1)->id);
+
+        $response->assertStatus(Response::HTTP_OK)
+            ->assertJsonFragment([
+                'name' => $request->get(1)->name,
+                'message' => $request->get(1)->message,
+                'created_at' => $request->get(1)->created_at,
+            ]);
+    }
+
+    /**
+     * Test deleting a specific request.
+     *
+     * @covers ::destroy
+     */
+    public function test_destroy(): void
+    {
+        $request = Request::factory(3)->create();
+
+        Sanctum::actingAs(User::factory()->create()->givePermissionTo([
+            RequestPermissions::CAN_DELETE_REQUESTS,
+        ])
+        );
+
+        $response = $this->delete('/api/v1/requests/' . $request->get(1)->id);
+
+        $response->assertStatus(Response::HTTP_NO_CONTENT);
+        $this->assertDatabaseMissing('requests', ['id' => $request->get(1)->id]);
+    }
+}


### PR DESCRIPTION
Introduce Wishbox request model and create API endpoints for listing, showing, creating, and deleting requests. Implement permissions to control access for viewing and deleting requests.

---
 - Close: #23 
 - Close: #7 
 - Close: #8 
 - Close: #9 